### PR TITLE
Doc: specify API URL suffix (/v2) for external clients

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,3 +1,5 @@
 ## Configuration
 
 There is a configuration file at `/var/www/languagetool/languagetool.conf` (for the first install).
+
+To use this server as an external server (e.g. in the browser extension or a plugin), you must append `/v2` to the end of the URL (e.g. `https://your-domain.tld/v2`).

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,3 +1,5 @@
 ## Configuration
 
 Il y a un fichier de configuration à `/var/www/languagetool/languagetool.conf` (pour la première installation).
+
+Pour utiliser ce serveur comme serveur externe (par exemple dans l'extension navigateur ou un plugin), il faut ajouter `/v2` à la fin de l'URL (ex: `https://votre-domaine.tld/v2`).


### PR DESCRIPTION
Added instructions to ADMIN.md and ADMIN_fr.md explaining that `/v2` must be appended to the server URL (e.g., `https://domain.tld/v2`) when configuring external clients like browser extensions.

Fix #39, Fix #22

## Problem

- Users were confused about which URL to use when configuring external clients (like browser extensions or plugins). They weren't aware that the suffix `/v2` is mandatory.

## Solution

- Added clear documentation in `doc/ADMIN.md` and `doc/ADMIN_fr.md` with examples showing the correct URL format (e.g., `https://your-domain.tld/v2`).

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
